### PR TITLE
Move input and output streams to methods on `Opts`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,23 +2,14 @@ pub mod opts;
 
 use std::{
     collections::VecDeque,
-    fs::File,
-    io::{self, BufRead, BufReader, BufWriter, Result, Write},
+    io::{BufRead, Result, Write},
 };
 
 use opts::Opts;
 
 pub fn headtail(opts: &Opts) -> Result<()> {
-    // Way to read from a file or stdout
-    let mut reader: Box<dyn BufRead> = if opts.filename.is_some() {
-        let file = File::open(opts.filename.as_ref().unwrap())?;
-        Box::new(BufReader::new(file))
-    } else {
-        Box::new(BufReader::new(io::stdin()))
-    };
-
-    // Way to write to stdout (and maybe in the future to a file)
-    let mut writer: Box<dyn Write> = Box::new(BufWriter::new(io::stdout()));
+    let mut reader = opts.input_stream()?;
+    let mut writer = opts.output_stream()?;
 
     // Do our head/tail thing
     let mut tail_buffer: VecDeque<String> = VecDeque::with_capacity(opts.tail + 1);

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,3 +1,8 @@
+use std::{
+    fs::OpenOptions,
+    io::{BufRead, BufReader, BufWriter, Write},
+};
+
 use clap::Parser;
 
 #[derive(Debug, clap::Parser)]
@@ -24,10 +29,38 @@ pub struct Opts {
         long = "follow"
     )]
     pub follow: bool,
+
+    /// Write output to file
+    #[clap(short = 'o', long = "outfile")]
+    pub outfile: Option<String>,
 }
 
 impl Opts {
     pub fn parse_args() -> Self {
         Self::parse()
+    }
+
+    /// Stream to receive input from. Either the file passed, or stdin otherwise.
+    pub fn input_stream(&self) -> std::io::Result<Box<dyn BufRead>> {
+        let stream: Box<dyn BufRead> = match self.filename {
+            Some(ref filename) => {
+                let file = OpenOptions::new().read(true).open(filename)?;
+                Box::new(BufReader::new(file))
+            }
+            None => Box::new(BufReader::new(std::io::stdin())),
+        };
+        Ok(stream)
+    }
+
+    /// Stream to write output to. Either the file passed, or stdout otherwise.
+    pub fn output_stream(&self) -> std::io::Result<Box<dyn Write>> {
+        let stream: Box<dyn Write> = match self.outfile {
+            Some(ref filename) => {
+                let file = OpenOptions::new().write(true).create(true).open(filename)?;
+                Box::new(BufWriter::new(file))
+            }
+            None => Box::new(BufWriter::new(std::io::stdout())),
+        };
+        Ok(stream)
     }
 }


### PR DESCRIPTION
Moves the input and output streams into their own methods.