### PR TITLE
Add file notifier integration into the 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
 
 env:
@@ -12,33 +12,32 @@ env:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Fetch cargo registry cache
-      uses: actions/cache@v3
-      continue-on-error: false
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-          Cargo.lock
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    
-    - name: Build
-      run: cargo build --verbose
+      - uses: actions/checkout@v3
 
-    - name: rustfmt & clippy
-      run: |
-        rustup component add clippy rustfmt
-        cargo clippy --workspace
-        cargo fmt --all -- --check
+      - name: Fetch cargo registry cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+            Cargo.lock
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Build
+        run: cargo build
+
+      - name: rustfmt & clippy
+        run: |
+          rustup component add clippy rustfmt
+          cargo clippy --workspace
+          cargo fmt --all -- --check
+
+      - name: Run tests
+        run: RUST_LOG=trace cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
           cargo fmt --all -- --check
 
       - name: Run tests
-        run: RUST_LOG=trace cargo test
+        run: RUST_LOG=trace cargo test -- --show-output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,6 @@ jobs:
           cargo fmt --all -- --check
 
       - name: Run tests
-        run: RUST_LOG=trace cargo test -- --show-output
+        run: cargo test -- --show-output
+        env:
+          RUST_LOG: trace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- CI builds are now available on pull requests (including caching, rustfmt, and clippy)
+
+### Fixed
+
+- Don't crash when writing to a broken pipe
+- Reduce follow from a busy loop (100% CPU) to a user-configurable sleep interval that defaults to 25ms (0.2% CPU in local testing)
+
+### Other
+
+- Refactored where the input streams are created
+
 
 ## [0.2.0] - 2022-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- CI now runs on macOS in addition to Linux. Now we just need someone to help us [support Windows](https://github.com/CleanCut/headtail/issues/21)!
+
+### Improved
+
+- We now use a notify-based watcher (inotify on Linux, etc.) when available to avoid polling.
+- Internal improvements.
+
 ## [0.3.0] - 2022-09-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+## [0.3.0] - 2022-09-15
+
 ### Added
 
 - CI builds are now available on pull requests (including caching, rustfmt, and clippy)
@@ -43,6 +45,7 @@ OPTIONS:
 Placeholder release to reserve the name.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/CleanCut/headtail/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/CleanCut/headtail/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/CleanCut/headtail/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/CleanCut/headtail/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/CleanCut/headtail/compare/v0.0.0...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "3.2.21", features = ["derive"] }
+notify = "5.0.0"
 thiserror = "1.0.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.21", features = ["derive"] }
+clap = { version = "3.2.21", features = [ "derive" ] }
+crossbeam-channel = "0.5.6"
+env_logger = "0.9.1"
+log = "0.4.17"
 notify = "5.0.0"
 thiserror = "1.0.35"
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "3.2.21", features = ["derive"] }
+thiserror = "1.0.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headtail"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "head and tail simultaneously"
 homepage = "https://github.com/CleanCut/headtail"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ You need to [have Rust installed](https://www.rust-lang.org/tools/install).
 ```shell
 # Install latest *release* version of headtail
 $ cargo install headtail
-
-# Install local development version of headtail from inside the git repo
-$ cargo install --path .
 ```
 
 ```
@@ -43,6 +40,19 @@ $ headtail somebigfile.txt -f
 ```
 
 See `headtail -h` for a full list of command-line options.
+
+## Development
+
+```
+# Run locally with arguments
+$ cargo run -- YOUR_ARGS_GO_HERE
+
+# Enable debug logging
+$ RUST_LOG=trace cargo run -- YOUR_ARGS_GO_HERE
+
+# Install local development version of headtail into your ~/.cargo/bin
+$ cargo install --path .
+```
 
 ## Software License
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,17 @@
 
 `head` and `tail` simultaneously
 
-TODO:
-- [x] Get a hello-world version published to crates.io to reserve the name
-- [x] Write integration tests. Run them with `cargo test`
-- [x] Create cheat sheet so we don't get stuck when we do our collaboration session.
-- [x] Sep 15th 2022, Day-of-Learning: Make the thing!
-  - [x] Review the existing project, including the release scaffolding
-  - [x] Run the (failing) tests
-  - [x] Implement the utility, handling arguments for file name (optional, read from stdin otherwise), number of lines to head, number of lines to tail, and whether or not to follow (iff input is a file).
-  - [x] Publish a release to crates.io
-- [ ] Parallel tasks folks could pick up for fun:
-  - [x] Set up GitHub Actions CI ([example from my rusty_engine project](https://github.com/CleanCut/rusty_engine/blob/main/.github/workflows/ci.yml))
-  - [ ] Set up CodeQL
-  - [ ] Set up Dependabot
-  - [ ] Improve Readme
-  - [x] More integration tests
-  - [ ] Unit tests
-  - [ ] Benchmark tests (see [criterion](https://bheisler.github.io/criterion.rs/book/index.html))
-- [ ] After initial implementation
-  - [ ] Any `TODO`s
-  - [ ] Option to output to file
-  - [ ] Better error handling
-  - [ ] Does this work on Windows?
-  - [ ] Screencast video for readme (put the video in a PR/issue comment and use the URL in the readme)
+Easy Ways to Contribute!
+- [ ] Set up CodeQL
+- [ ] Set up Dependabot
+- [ ] Improve Readme
+- [ ] Add integration test for -f/--follow
+- [ ] Add integration test for -s/--sleep-interval
+- [ ] Add (any) unit tests
+- [ ] Add (any) benchmark tests (see [criterion](https://bheisler.github.io/criterion.rs/book/index.html))
+- [ ] Add option to output to file
+- [ ] Find out if this even works on Windows
+- [ ] Make demo video for readme (put the video in a PR/issue comment and use the URL in the readme)
 
 ## Quick Start
 
@@ -55,6 +43,8 @@ $ headtail somebigfile.txt -T 3
 # out anything new that is appended to it.
 $ headtail somebigfile.txt -f
 ```
+
+See `headtail -h` for a full list of command-line options.
 
 ## Software License
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum HeadTailError {
+    #[error("IO error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("File watcher error: {0}")]
+    FileWatcherError(#[from] notify::Error),
+}
+
+pub type Result<T> = std::result::Result<T, HeadTailError>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,5 +8,3 @@ pub enum HeadTailError {
     #[error("File watcher error: {0}")]
     FileWatcherError(#[from] notify::Error),
 }
-
-pub type Result<T> = std::result::Result<T, HeadTailError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod opts;
 
 use std::{
     collections::VecDeque,
-    io::{self, BufRead, ErrorKind, Write},
+    io::{BufRead, ErrorKind, Write},
     path::Path,
     time::Duration,
 };
@@ -13,12 +13,12 @@ use notify::{event::EventKind, Event, Watcher};
 use errors::Result;
 use opts::Opts;
 
-fn careful_write(writer: &mut dyn Write, line: &str) -> io::Result<()> {
+fn careful_write(writer: &mut dyn Write, line: &str) -> Result<()> {
     if let Err(e) = writer.write(line.as_bytes()) {
         if e.kind() == ErrorKind::BrokenPipe {
             return Ok(());
         } else {
-            return Err(e);
+            return Err(errors::HeadTailError::IOError(e));
         }
     }
     Ok(())
@@ -85,7 +85,7 @@ pub fn headtail(opts: &Opts) -> Result<()> {
                         Ok(_) => {
                             match careful_write(&mut writer, &line) {
                                 Ok(_) => {}
-                                Err(e) => eprintln!("Write error: {:?}", e.kind()),
+                                Err(e) => eprintln!("Write error: {:?}", e),
                             }
                             let _ = writer.flush();
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,23 +8,23 @@ use std::{
     time::Duration,
 };
 
+use errors::HeadTailError;
 use notify::{event::EventKind, Event, Watcher};
 
-use errors::Result;
 use opts::Opts;
 
-fn careful_write(writer: &mut dyn Write, line: &str) -> Result<()> {
+fn careful_write(writer: &mut dyn Write, line: &str) -> Result<(), HeadTailError> {
     if let Err(e) = writer.write(line.as_bytes()) {
         if e.kind() == ErrorKind::BrokenPipe {
             return Ok(());
         } else {
-            return Err(errors::HeadTailError::IOError(e));
+            return Err(HeadTailError::IOError(e));
         }
     }
     Ok(())
 }
 
-pub fn headtail(opts: &Opts) -> Result<()> {
+pub fn headtail(opts: &Opts) -> Result<(), HeadTailError> {
     let mut reader = opts.input_stream()?;
     let mut writer = opts.output_stream()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 use errors::HeadTailError;
 use log::trace;
-use notify::{event::EventKind, Event, Watcher};
+use notify::{event::EventKind, Watcher};
 
 use opts::Opts;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub fn headtail(opts: &Opts) -> Result<()> {
         )?;
 
         watcher.watch(
-            Path::new(&opts.filename.as_ref().unwrap()),
+            Path::new(opts.filename.as_ref().unwrap()),
             notify::RecursiveMode::NonRecursive,
         )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ fn careful_write(writer: &mut dyn Write, line: &str) -> Result<(), HeadTailError
         if e.kind() == ErrorKind::BrokenPipe {
             return Ok(());
         } else {
-            return Err(HeadTailError::IOError(e));
+            return Err(e.into());
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,8 @@ pub fn headtail(opts: &Opts) -> Result<(), HeadTailError> {
             config,
         )?;
 
+        // TODO: Figure out what to do about the possibility of a race condition between the initial
+        // headtail and the following. See https://github.com/CleanCut/headtail/pull/17/files#r973220630
         watcher.watch(
             Path::new(opts.filename.as_ref().unwrap()),
             notify::RecursiveMode::NonRecursive,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub fn headtail(opts: &Opts) -> Result<()> {
         let config = notify::Config::default().with_poll_interval(sleep_interval);
 
         // Setup the file watcher
-        let mut watcher =
-            notify::RecommendedWatcher::new(move |res: notify::Result<notify::Event>| match res {
+        let mut watcher = notify::RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| match res {
                 Ok(event) if is_modification(&event) => {
                     line.clear();
                     match reader.read_line(&mut line) {
@@ -97,7 +97,9 @@ pub fn headtail(opts: &Opts) -> Result<()> {
                 }
                 Ok(_) => {}
                 Err(e) => eprintln!("Watcher error: {:?}", e),
-            }, config)?;
+            },
+            config,
+        )?;
 
         watcher.watch(
             Path::new(&opts.filename.as_ref().unwrap()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use headtail::{errors::HeadTailError, headtail, opts::Opts};
 
 fn main() -> Result<(), HeadTailError> {
+    env_logger::init();
     let opts = Opts::parse_args();
     //println!("{opts:#?}");
     headtail(&opts)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
-use headtail::errors::Result;
+use headtail::{errors::HeadTailError, headtail, opts::Opts};
 
-use headtail::{headtail, opts::Opts};
-
-fn main() -> Result<()> {
+fn main() -> Result<(), HeadTailError> {
     let opts = Opts::parse_args();
     //println!("{opts:#?}");
     headtail(&opts)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use headtail::errors::Result;
 
 use headtail::{headtail, opts::Opts};
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -5,7 +5,7 @@ use std::{
 
 use clap::Parser;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct Opts {
     #[clap(help = "Read from a file instead of stdin")]
     pub filename: Option<String>,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -44,8 +44,8 @@ impl Opts {
     }
 
     /// Stream to receive input from. Either the file passed, or stdin otherwise.
-    pub fn input_stream(&self) -> std::io::Result<Box<dyn BufRead>> {
-        let stream: Box<dyn BufRead> = match self.filename {
+    pub fn input_stream(&self) -> std::io::Result<Box<dyn BufRead + Send>> {
+        let stream: Box<dyn BufRead + Send> = match self.filename {
             Some(ref filename) => {
                 let file = OpenOptions::new().read(true).open(filename)?;
                 Box::new(BufReader::new(file))
@@ -56,8 +56,8 @@ impl Opts {
     }
 
     /// Stream to write output to. Either the file passed, or stdout otherwise.
-    pub fn output_stream(&self) -> std::io::Result<Box<dyn Write>> {
-        let stream: Box<dyn Write> = match self.outfile {
+    pub fn output_stream(&self) -> std::io::Result<Box<dyn Write + Send>> {
+        let stream: Box<dyn Write + Send> = match self.outfile {
             Some(ref filename) => {
                 let file = OpenOptions::new().write(true).create(true).open(filename)?;
                 Box::new(BufWriter::new(file))

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -24,13 +24,16 @@ pub struct Opts {
     )]
     pub tail: usize,
     #[clap(
-        help = "Wait for additional data to be appended to a file. Ignored if standard input is a pipe.",
+        help = "Wait for additional data to be appended to a file. Ignored if standard input is a \
+            pipe. If a `notify`-compatible filesystem watcher is available, that will be used. If \
+            not, we will fall back to a polling watcher.",
         short = 'f',
         long = "follow"
     )]
     pub follow: bool,
     #[clap(short = 's', long = "sleep-interval", default_value_t = 0.025)]
-    /// When following a file, sleep this amount in seconds between polling for changes.
+    /// When following a file, sleep this amount in seconds between polling for changes. Ignored if
+    /// a `notify`-compatible watcher is available.
     pub sleep_interval: f64,
 
     /// Write output to file

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -171,7 +171,7 @@ fn overlapping_head_and_tail() {
 #[test]
 fn follow_detects_recreation() -> Result<()> {
     if let Ok(ci_var) = std::env::var("CI") {
-        if !ci_var.is_empty() && cfg!(linux) {
+        if !ci_var.is_empty() && cfg!(target_os = "linux") {
             eprintln!("WARNING: Ignoring follow_detects_recreation test on Linux CI since this feature doesn't work with the fallback polling strategy.");
             return Ok(());
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,7 +170,7 @@ fn overlapping_head_and_tail() {
 
 #[test]
 fn follow_detects_recreation() -> Result<()> {
-    let wait_duration = Duration::from_millis(750); // 20 times higher than minimum required for my machine - cleancut
+    let wait_duration = Duration::from_millis(125); // 5 times higher than minimum required for my machine - cleancut
     let first_file_contents = "first file\n";
     let second_file_contents = "second file\n";
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -172,8 +172,8 @@ fn overlapping_head_and_tail() {
 fn follow_detects_recreation() -> Result<()> {
     if let Ok(ci_var) = std::env::var("CI") {
         if !ci_var.is_empty() && cfg!(linux) {
-            eprintln!("WARNING: Ignoring follow_detects_recreation test on Linux CI since this feature doesn't work with the fallback polling strategy.")
-            return Ok(())
+            eprintln!("WARNING: Ignoring follow_detects_recreation test on Linux CI since this feature doesn't work with the fallback polling strategy.");
+            return Ok(());
         }
     }
     let wait_duration = Duration::from_millis(125); // 5 times higher than minimum required for my machine - cleancut

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,7 +170,7 @@ fn overlapping_head_and_tail() {
 
 #[test]
 fn follow_detects_recreation() -> Result<()> {
-    let wait_duration = Duration::from_millis(100); // 4 times higher than minimum required for my machine - cleancut
+    let wait_duration = Duration::from_millis(250); // 10 times higher than minimum required for my machine - cleancut
     let first_file_contents = "first file\n";
     let second_file_contents = "second file\n";
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,7 +170,7 @@ fn overlapping_head_and_tail() {
 
 #[test]
 fn follow_detects_recreation() -> Result<()> {
-    let wait_duration = Duration::from_millis(250); // 10 times higher than minimum required for my machine - cleancut
+    let wait_duration = Duration::from_millis(500); // 20 times higher than minimum required for my machine - cleancut
     let first_file_contents = "first file\n";
     let second_file_contents = "second file\n";
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,6 +170,12 @@ fn overlapping_head_and_tail() {
 
 #[test]
 fn follow_detects_recreation() -> Result<()> {
+    if let Ok(ci_var) = std::env::var("CI") {
+        if !ci_var.is_empty() && cfg!(linux) {
+            eprintln!("WARNING: Ignoring follow_detects_recreation test on Linux CI since this feature doesn't work with the fallback polling strategy.")
+            return Ok(())
+        }
+    }
     let wait_duration = Duration::from_millis(125); // 5 times higher than minimum required for my machine - cleancut
     let first_file_contents = "first file\n";
     let second_file_contents = "second file\n";

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,7 +170,7 @@ fn overlapping_head_and_tail() {
 
 #[test]
 fn follow_detects_recreation() -> Result<()> {
-    let wait_duration = Duration::from_millis(500); // 20 times higher than minimum required for my machine - cleancut
+    let wait_duration = Duration::from_millis(750); // 20 times higher than minimum required for my machine - cleancut
     let first_file_contents = "first file\n";
     let second_file_contents = "second file\n";
 


### PR DESCRIPTION
Uses the `notify` crate in order to use the file watching/notification functionality often provided by operating systems (eg `inotify(7)` on Linux.

Also wraps `io::Error` and `notify::Error` into a custom error type using `thiserror`.

Closes #16 