### PR TITLE
Move argument help documentation

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -7,21 +7,13 @@ use clap::Parser;
 
 #[derive(Debug, clap::Parser)]
 pub struct Opts {
-    #[clap(help = "Read from a file instead of stdin")]
+    /// Read from a file instead of stdin
     pub filename: Option<String>,
-    #[clap(
-        help = "Number of first lines of a file to display",
-        short = 'H',
-        long = "head",
-        default_value_t = 10
-    )]
+    /// Number of first lines of a file to display
+    #[clap(short = 'H', long = "head", default_value_t = 10)]
     pub head: usize,
-    #[clap(
-        help = "Number of last lines of a file to display",
-        short = 'T',
-        long = "tail",
-        default_value_t = 10
-    )]
+    /// Number of last lines of a file to display
+    #[clap(short = 'T', long = "tail", default_value_t = 10)]
     pub tail: usize,
     #[clap(
         help = "Wait for additional data to be appended to a file. Ignored if standard input is a pipe.",

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -21,8 +21,8 @@ pub struct Opts {
         long = "follow"
     )]
     pub follow: bool,
-    #[clap(short = 's', long = "sleep-interval", default_value_t = 0.025)]
     /// When following a file, sleep this amount in seconds between polling for changes.
+    #[clap(short = 's', long = "sleep-interval", default_value_t = 0.025)]
     pub sleep_interval: f64,
 
     /// Write output to file


### PR DESCRIPTION
Move the documentation for the arguments into comments to better support `cargo doc`

Note: this does not currently move the documentation for the `-f`/`--follow` argument to make rebasing #17 easier.