### PR TITLE
feat: add option to show how many lines were omitted

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,14 @@ pub fn headtail(opts: &Opts) -> Result<(), HeadTailError> {
     // Do our head/tail thing
     let mut tail_buffer: VecDeque<String> = VecDeque::with_capacity(opts.tail + 1);
     let mut line_num = 0;
+    let mut omitted = 0;
     loop {
         let mut line = String::new();
         match reader.read_line(&mut line)? {
             0 => {
+                if opts.separator && !tail_buffer.is_empty() && omitted > 0 {
+                    careful_write(&mut writer, &format!("[... {} line(s) omitted ...]\n", omitted))?;
+                }
                 for tail_line in &tail_buffer {
                     careful_write(&mut writer, tail_line)?;
                 }
@@ -52,6 +56,7 @@ pub fn headtail(opts: &Opts) -> Result<(), HeadTailError> {
                     tail_buffer.push_back(line);
                     if tail_buffer.len() > opts.tail {
                         tail_buffer.pop_front();
+                        omitted += 1;
                     }
                 }
             }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -29,6 +29,10 @@ pub struct Opts {
     /// Write output to file
     #[arg(short, long)]
     pub outfile: Option<String>,
+
+    /// Show separator between head and tail
+    #[arg(short = 'S', long, default_value_t = false)]
+    pub separator: bool,
 }
 
 impl Opts {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -166,6 +166,23 @@ fn overlapping_head_and_tail() {
     }
 }
 
+#[test]
+fn show_separator() {
+    match Command::new(env!("CARGO_BIN_EXE_headtail"))
+        .arg("tests/files/input.txt")
+        .arg("-S")
+        .output()
+    {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let num_lines = stdout.lines().count();
+            assert_eq!(num_lines, 10 + 10 + 1);
+            assert!(stdout.contains(&format!("[... {} line(s) omitted ...]", number_of_input_lines() - 20)));
+        }
+        Err(e) => println!("Error: {}", e),
+    }
+}
+
 // TODO: Add test for -f/--follow
 
 #[test]


### PR DESCRIPTION
Adds -S/--separator to show the break point and the number of lines that were skipped.

```
$ headtail -S tests/files/input.txt 
one
two
three
four
five
six
seven
eight
nine
ten
[... 10 line(s) omitted ...]
twenty-one
twenty-two
twenty-three
twenty-four
twenty-five
twenty-six
twenty-seven
twenty-eight
twenty-nine
thirty
```